### PR TITLE
Use fill mode instead of fluid mode for Video.js player

### DIFF
--- a/templates/shortcodes/es_cdn_video.html
+++ b/templates/shortcodes/es_cdn_video.html
@@ -49,8 +49,7 @@
   (function () {
     var initPlayer = function() {
       var player = window.videojs(document.getElementById({{ id | json_encode() | safe }}), {
-        fluid: true,
-        responsive: true,
+        fill: true,
         html5: {
           vhs: {
             // Don't start with lowest quality; use bandwidth estimation from the start.


### PR DESCRIPTION
The CSS wrapper already handles aspect ratio via aspect-ratio: 16/9, with the player absolutely positioned to fill it. Using fluid: true caused Video.js to add padding-top: 56.25% (the old padding-top hack) which conflicted with the absolute positioning and caused the player to expand when video metadata loaded on play.

Switching to fill: true tells Video.js to simply fill its container
(width: 100%; height: 100%), which matches the CSS setup correctly.